### PR TITLE
Sort parent index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development, :test do
   gem "launchy"
   gem "simplecov"
   gem 'shoulda-matchers', '~> 6.0'
+  gem 'orderly'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
+    orderly (0.1.1)
+      capybara (>= 1.1)
+      rspec (>= 2.14)
     pg (1.5.4)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -206,6 +209,10 @@ GEM
     regexp_parser (2.9.0)
     reline (0.4.2)
       io-console (~> 0.5)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -275,6 +282,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   launchy
+  orderly
   pg (~> 1.1)
   pry
   puma (>= 5.0)

--- a/app/models/record_label.rb
+++ b/app/models/record_label.rb
@@ -1,3 +1,7 @@
 class RecordLabel < ApplicationRecord
     has_many :artists
+
+    def sort
+        RecordLabel.order(:created_at)
+    end
 end

--- a/spec/features/record_labels/index_spec.rb
+++ b/spec/features/record_labels/index_spec.rb
@@ -1,24 +1,34 @@
 require 'rails_helper'
 
 RSpec.describe 'Record Labels index page', type: :feature do
-    it 'see the name of each record label' do
-        xl = RecordLabel.create!(name: "XL Recordings", major_label: false, launched_tours: 100, genre_focus: "Punk Rock")
+    let!(:xl) {RecordLabel.create!(name: "XL Recordings", major_label: false, launched_tours: 100, genre_focus: "Punk Rock")}
+    let!(:tde) {RecordLabel.create!(name: "Top Dawg Entertainment", major_label: false, launched_tours: 6, genre_focus: "Hip-Hop")}
+    let!(:motown) {RecordLabel.create!(name: "Motown", major_label: true, launched_tours: 35, genre_focus: "R&B")}
 
+    before :each do
         visit '/recordlabels'
+    end
+
+    it 'see the name of each record label' do
 
         expect(page).to have_content(xl.name)
     end
 
     describe 'record label names link to their own show page' do
         it 'will direct them to individual record show page' do
-            xl = RecordLabel.create!(name: "XL Recordings", major_label: false, launched_tours: 100, genre_focus: "Punk Rock")
-
-            visit "/recordlabels/"
 
             click_on xl.name
 
             expect(current_path).to eq("/recordlabels/#{xl.id}")
         end
 
+    end
+
+    describe 'user story 6' do
+        it 'order of record labels to be ordered by most recently created' do
+            expect("XL Recordings").to appear_before("Top Dawg Entertainment")
+
+            expect(motown.name).to_not appear_before(tde.name)
+        end
     end
 end

--- a/spec/models/record_label_spec.rb
+++ b/spec/models/record_label_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe RecordLabel, type: :model do
+
+    let!(:motown) {RecordLabel.create!(name: "Motown", major_label: true, launched_tours: 35, genre_focus: "R&B")}
+    let!(:tde) {RecordLabel.create!(name: "Top Dawg Entertainment", major_label: false, launched_tours: 6, genre_focus: "Hip-Hop")}
+    let!(:dreamville) {RecordLabel.create!(name: "Dreamville", major_label: false, launched_tours: 3, genre_focus: "Hip-Hop")}
+
+    describe 'relationships' do
+        it {should have_many :artists}
+    end
+
+    describe '#sort' do
+        it 'sorts the labels by most recently created' do
+            labels = [dreamville, motown, tde]
+            expect(labels.sort).to eq ([motown, tde, dreamville])
+        end
+    end
+end


### PR DESCRIPTION
1. display order of record labels by most recently created date
2. orderly gem helps feature testing to expect text to appear (or not appear) before some other text on the page