### PR TITLE
Display links to all index pages on the top of each page 

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
   </head>
 
   <body>
+    <h3><a href="/">Home</a>&nbsp;&nbsp;<a href="/recordlabels">Record Labels</a>&nbsp;&nbsp;<a href="/artists">Artists</a></h3>
     <%= yield %>
   </body>
 </html>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,6 +1,1 @@
 <h1>Record Label and Artist Management</h1>
-
-<ul>
-    <li><a href="/recordlabels">Record Labels</a></li>
-    <li><a href="/artists">Artists</a></li>
-</ul>

--- a/spec/features/record_labels/show_spec.rb
+++ b/spec/features/record_labels/show_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe 'Record Labels show page', type: :feature do
             end
         end
     end
+
+    describe 'user story 8' do
+        it 'displays a link on each page leading to all index pages' do
+            expect(page).to have_link('Home', href: '/')
+            expect(page).to have_link('Record Labels', href: '/recordlabels')
+            expect(page).to have_link('Artists', href: '/artists')
+        end
+    end
 end
 
 #<div id=“player_<%= player.id %>”></div>


### PR DESCRIPTION
Display links to all index pages on the top of each page by adding html to application.htm.erb file

fulfills user story 8 and 9